### PR TITLE
Fix: Add var to specify target project

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -5,7 +5,7 @@ data "google_project" "project" {
 locals {
   sa_impersonation_filter_attribute = var.sa_impersonation_filter_attribute == "" ? "attribute.org_id" : var.sa_impersonation_filter_attribute
   sa_impersonation_filter_value     = var.sa_impersonation_filter_value == "" ? var.circleci_org_id : var.sa_impersonation_filter_value
-  project_id = data.google_project.project.project_id
+  project_id                        = data.google_project.project.project_id
 }
 
 data "google_service_account" "existing_sa" {

--- a/data.tf
+++ b/data.tf
@@ -1,12 +1,14 @@
-data "google_project" "project" {}
+data "google_project" "project" {
+  project_id = var.project_id
+}
 
 locals {
   sa_impersonation_filter_attribute = var.sa_impersonation_filter_attribute == "" ? "attribute.org_id" : var.sa_impersonation_filter_attribute
   sa_impersonation_filter_value     = var.sa_impersonation_filter_value == "" ? var.circleci_org_id : var.sa_impersonation_filter_value
+  project_id = data.google_project.project.project_id
 }
 
 data "google_service_account" "existing_sa" {
-  #count      = var.existing_service_account_email == "" ? 0 : 1
   for_each = var.existing_service_account_email == "" ? toset([]) : toset([var.existing_service_account_email])
 
   account_id = var.existing_service_account_email

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "google_service_account_iam_member" "circleci_impersonation" {
 resource "google_project_iam_member" "project" {
   for_each = var.roles_to_bind
 
-  project = data.google_project.project.project_id
+  project = var.project_id
   role    = each.value
   member  = "serviceAccount:${var.existing_service_account_email == "" ? google_service_account.circleci[0].email : data.google_service_account.existing_sa[var.existing_service_account_email].email}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "circleci_org_id" {
   description = "Your CircleCI org ID.  Can be found under \"Organization Settings\" in the CircleCI application."
 }
 
+variable "project_id" {
+  type        = string
+  description = "Your Google Project ID."
+}
+
 #-------------------------------------------------------------------------------
 # OPTIONAL VARS
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Terraform doesn't like when `resource "google_project_iam_member" "project" {}` uses a dynamic `project`, unfortunately.  This adds a var so that it can be supplied as a string when invoking the module.